### PR TITLE
Responsive grids 2

### DIFF
--- a/.github/prompts/tw-classnames-split.prompt.md
+++ b/.github/prompts/tw-classnames-split.prompt.md
@@ -1,0 +1,26 @@
+Your goal is to refactor React components to use `clsx` for managing `className` values.
+
+Requirements for the refactor:
+
+- Convert all `className` strings, for all react components in the file, to use `clsx` array syntax.
+- Split class names by whitespace and apply `clsx` like so: `className={clsx(['flex', 'flex-full'])}`.
+- Ensure readability and maintainability of the updated code.
+- Test the components to verify that the visual appearance remains unchanged.
+- Follow best practices for clean and consistent code.
+- import clsx if required
+- replace other className utilities if required e.g. `cn` -> `clsx`
+
+Example:
+Before:
+
+```jsx
+<div className="flex flex-full"></div>
+```
+
+After:
+
+```jsx
+import clsx from "clsx";
+
+<div className={clsx(["flex", "flex-full"])}></div>;
+```

--- a/src/components/Accordion.stories.tsx
+++ b/src/components/Accordion.stories.tsx
@@ -15,7 +15,7 @@ export default meta;
 type Story = StoryObj<typeof Accordion>;
 
 export const Default: Story = {
-  name: "Default Accordion",
+  name: "Accordion",
   args: {
     items: [
       {

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import * as React from "react";
+import { useState } from "react";
 import {
   AccordionContent,
   AccordionItem,
@@ -17,7 +18,7 @@ export const Accordion: React.FC<AccordionProps> = ({
   items,
   collapsible = true,
 }) => {
-  const [openValue, setOpenValue] = React.useState<string | undefined>();
+  const [openValue, setOpenValue] = useState<string | undefined>();
 
   return (
     <ShadcnAccordion

--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import Button, { ButtonProps } from "./Button";
+import { Button, ButtonProps } from "./Button";
 
 const meta: Meta<ButtonProps> = {
   title: "Components/Button",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -2,7 +2,9 @@ import * as React from "react";
 import { ButtonProps, Button as ShadcnButton } from "./shadcn/button";
 import { withTooltip } from "./withTooltip";
 
-export const Button: React.FC<ButtonProps & { tooltip?: string }> = withTooltip(
+export const Button: React.FC<
+  ButtonProps & { tooltip?: string; tooltipClassName?: string }
+> = withTooltip(
   ({ variant = "default", size = "sm", children, onClick, ...props }) => {
     return (
       <ShadcnButton variant={variant} size={size} onClick={onClick} {...props}>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,20 +1,15 @@
 import * as React from "react";
 import { ButtonProps, Button as ShadcnButton } from "./shadcn/button";
+import { withTooltip } from "./withTooltip";
 
-export const Button: React.FC<ButtonProps> = ({
-  variant = "default",
-  size = "sm",
-  children,
-  onClick,
-  ...props
-}) => {
-  return (
-    <ShadcnButton variant={variant} size={size} onClick={onClick} {...props}>
-      {children}
-    </ShadcnButton>
-  );
-};
+export const Button: React.FC<ButtonProps & { tooltip?: string }> = withTooltip(
+  ({ variant = "default", size = "sm", children, onClick, ...props }) => {
+    return (
+      <ShadcnButton variant={variant} size={size} onClick={onClick} {...props}>
+        {children}
+      </ShadcnButton>
+    );
+  },
+);
 
 export type { ButtonProps } from "./shadcn/button";
-
-export default Button;

--- a/src/components/Collapsible.stories.tsx
+++ b/src/components/Collapsible.stories.tsx
@@ -15,7 +15,7 @@ export default meta;
 type Story = StoryObj<typeof Collapsible>;
 
 export const Default: Story = {
-  name: "Default Collapsible",
+  name: "Collapsible",
   args: {
     Title: "Click to Expand",
     children: <div className="p-2">This is the collapsible content.</div>,

--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@iconify/react";
 import clsx from "clsx";
 import { AnimatePresence, motion } from "framer-motion";
 import * as React from "react";
+import { useState } from "react";
 import { Button } from "./Button";
 
 type CollapsibleProps = {
@@ -13,6 +14,7 @@ type CollapsibleProps = {
   children: React.ReactNode;
   titleClassName?: string;
   contentClassName?: string;
+  initialOpen?: boolean;
 };
 
 export const Collapsible: React.FC<CollapsibleProps> = ({
@@ -20,8 +22,9 @@ export const Collapsible: React.FC<CollapsibleProps> = ({
   children,
   titleClassName,
   contentClassName,
+  initialOpen = false,
 }) => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(initialOpen);
 
   return (
     <CollapsibleRoot open={open} onOpenChange={setOpen}>

--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -2,12 +2,11 @@ import {
   Collapsible as CollapsibleRoot,
   CollapsibleTrigger,
 } from "@/components/shadcn/collapsible";
-import { Icon } from "@iconify/react";
 import clsx from "clsx";
 import { AnimatePresence, motion } from "framer-motion";
 import * as React from "react";
 import { useState } from "react";
-import { Button } from "./Button";
+import { ToggleButton } from "./ToggleButton";
 
 type CollapsibleProps = {
   Title: string | React.ReactNode;
@@ -58,9 +57,11 @@ export const Collapsible: React.FC<CollapsibleProps> = ({
           Title
         )}
         <CollapsibleTrigger asChild>
-          <Button
-            variant="rounded"
-            size="icon"
+          <ToggleButton
+            isOpen={open}
+            onClick={() => {
+              setOpen(!open);
+            }}
             className={clsx([
               "bg-gradient-to-r",
               "from-blue-500",
@@ -79,51 +80,7 @@ export const Collapsible: React.FC<CollapsibleProps> = ({
               "transition-opacity",
               "duration-300",
             ])}
-            onClick={(e) => {
-              e.stopPropagation();
-              setOpen(() => !open);
-            }}
-          >
-            <AnimatePresence initial={false}>
-              {open ? (
-                <motion.div
-                  key="cross"
-                  initial={{ opacity: 0, scale: 0.8 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  exit={{ opacity: 0, scale: 0.8 }}
-                  transition={{ duration: 0.2 }}
-                  className={clsx(["absolute", "flex", "place-items-center"])}
-                >
-                  <Icon
-                    className={clsx([
-                      "text-slate-100",
-                      "dark:text-slate-100",
-                      "size-[20px]",
-                    ])}
-                    icon={"radix-icons:cross-2"}
-                  />
-                </motion.div>
-              ) : (
-                <motion.div
-                  key="row-spacing"
-                  initial={{ opacity: 0, scale: 0.8 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  exit={{ opacity: 0, scale: 0.8 }}
-                  transition={{ duration: 0.2 }}
-                  className={clsx(["absolute"])}
-                >
-                  <Icon
-                    className={clsx([
-                      "text-slate-100",
-                      "dark:text-slate-100",
-                      "size-[20px]",
-                    ])}
-                    icon={"radix-icons:row-spacing"}
-                  />
-                </motion.div>
-              )}
-            </AnimatePresence>
-          </Button>
+          />
         </CollapsibleTrigger>
       </div>
 

--- a/src/components/Drawer.stories.tsx
+++ b/src/components/Drawer.stories.tsx
@@ -28,6 +28,7 @@ export default meta;
 type Story = StoryObj<typeof Drawer>;
 
 export const Default: Story = {
+  name: "Drawer",
   render: () => {
     const [goal, setGoal] = useState(350);
 

--- a/src/components/Drawer.stories.tsx
+++ b/src/components/Drawer.stories.tsx
@@ -2,7 +2,7 @@ import { Icon } from "@iconify/react";
 import type { Meta, StoryObj } from "@storybook/react";
 import clsx from "clsx";
 import { useState } from "react";
-import Button from "./Button";
+import { Button } from "./Button";
 import {
   Drawer,
   DrawerClose,

--- a/src/components/Drawer.stories.tsx
+++ b/src/components/Drawer.stories.tsx
@@ -17,9 +17,6 @@ const meta: Meta<typeof Drawer> = {
   component: Drawer,
   parameters: {
     layout: "centered",
-    controls: {
-      disable: true,
-    },
   },
 };
 

--- a/src/components/Drawer.stories.tsx
+++ b/src/components/Drawer.stories.tsx
@@ -24,8 +24,8 @@ export default meta;
 
 type Story = StoryObj<typeof Drawer>;
 
-export const Default: Story = {
-  name: "Drawer",
+export const BottomDrawer: Story = {
+  name: "Drawer (Bottom Aligned)",
   render: () => {
     const [goal, setGoal] = useState(350);
 
@@ -34,7 +34,110 @@ export const Default: Story = {
     }
 
     return (
-      <Drawer contentClassName="dark">
+      <Drawer contentClassName="dark" direction="bottom">
+        <div className={clsx(["mx-auto", "w-full", "dark:text-white"])}>
+          <DrawerHeader>
+            <DrawerTitle>Move Goal</DrawerTitle>
+            <DrawerDescription>Set your daily activity goal.</DrawerDescription>
+          </DrawerHeader>
+          <div className={clsx(["p-4", "pb-0"])}>
+            <div
+              className={clsx([
+                "flex",
+                "items-center",
+                "justify-center",
+                "space-x-2",
+              ])}
+            >
+              <Button
+                variant="outline"
+                size="icon"
+                className={clsx([
+                  "h-8",
+                  "w-8",
+                  "shrink-0",
+                  "rounded-full",
+                  "dark:bg-gray-700",
+                  "dark:border-gray-600",
+                ])}
+                onClick={() => onClick(-10)}
+                disabled={goal <= 200}
+              >
+                <Icon icon={"mdi:minus"} />
+                <span className={clsx(["sr-only"])}>Decrease</span>
+              </Button>
+              <div className={clsx(["flex-1", "text-center"])}>
+                <div
+                  className={clsx([
+                    "text-7xl",
+                    "font-bold",
+                    "tracking-tighter",
+                  ])}
+                >
+                  {goal}
+                </div>
+                <div
+                  className={clsx([
+                    "text-[0.70rem]",
+                    "uppercase",
+                    "text-muted-foreground",
+                    "dark:text-gray-400",
+                  ])}
+                >
+                  Calories/day
+                </div>
+              </div>
+              <Button
+                variant="outline"
+                size="icon"
+                className={clsx([
+                  "h-8",
+                  "w-8",
+                  "shrink-0",
+                  "rounded-full",
+                  "dark:bg-gray-700",
+                  "dark:border-gray-600",
+                ])}
+                onClick={() => onClick(10)}
+                disabled={goal >= 400}
+              >
+                <Icon icon={"mdi:plus"} />
+                <span className={clsx(["sr-only"])}>Increase</span>
+              </Button>
+            </div>
+          </div>
+          <DrawerFooter>
+            <Button
+              className={clsx(["dark:bg-gray-700", "dark:border-gray-600"])}
+            >
+              Submit
+            </Button>
+            <DrawerClose asChild>
+              <Button
+                variant="outline"
+                className={clsx(["dark:bg-gray-700", "dark:border-gray-600"])}
+              >
+                Cancel
+              </Button>
+            </DrawerClose>
+          </DrawerFooter>
+        </div>
+      </Drawer>
+    );
+  },
+};
+
+export const RightDrawer: Story = {
+  name: "Drawer (Right Aligned)",
+  render: () => {
+    const [goal, setGoal] = useState(350);
+
+    function onClick(adjustment: number) {
+      setGoal(Math.max(200, Math.min(400, goal + adjustment)));
+    }
+
+    return (
+      <Drawer contentClassName="dark" direction="right">
         <div className={clsx(["mx-auto", "w-full", "dark:text-white"])}>
           <DrawerHeader>
             <DrawerTitle>Move Goal</DrawerTitle>

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -1,5 +1,6 @@
+import { ToggleButton } from "@/components";
 import clsx from "clsx";
-import { Button } from "./Button";
+import { useState } from "react";
 import {
   DrawerClose,
   DrawerContent,
@@ -7,7 +8,6 @@ import {
   DrawerFooter,
   DrawerHeader,
   DrawerTitle,
-  DrawerTrigger,
   Drawer as ShadcnDrawer,
   DrawerProps as ShadcnDrawerProps,
 } from "./shadcn/drawer";
@@ -25,6 +25,10 @@ interface DrawerProps {
   initialIsOpen?: boolean;
   showHandle?: boolean;
   direction?: ShadcnDrawerProps["direction"];
+  openDrawerTooltip?: string;
+  closeDrawerTooltip?: string;
+  customOpenIcon?: string;
+  customCloseIcon?: string;
 }
 
 export const Drawer: React.FC<DrawerProps> = ({
@@ -35,38 +39,80 @@ export const Drawer: React.FC<DrawerProps> = ({
   initialIsOpen = false,
   showHandle,
   direction = "right",
+  openDrawerTooltip = "Open",
+  closeDrawerTooltip = "Close",
+  customOpenIcon,
+  customCloseIcon,
   ...props
 }) => {
+  const [isOpen, setIsOpen] = useState(initialIsOpen);
+
+  const handleToggle = () => {
+    setIsOpen((prev) => !prev);
+  };
+
   return (
     <>
-      <ShadcnDrawer direction={direction} {...props}>
-        <DrawerTrigger>
-          {TriggerButton ?? (
-            <Button className={clsx(triggerClassName)}>Open</Button>
-          )}
-        </DrawerTrigger>
-
-        <DrawerContent
-          showHandle={showHandle}
-          className={clsx(["dark", contentClassName])}
-        >
-          <DrawerTrigger
+      <ShadcnDrawer
+        direction={direction}
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        {...props}
+      >
+        {direction === "right" ? (
+          <ToggleButton
+            size="lg"
+            isOpen={isOpen}
+            onClick={handleToggle}
+            direction={customOpenIcon ? "vertical" : "horizontal"}
+            tooltipOpen={openDrawerTooltip}
+            tooltipClose={closeDrawerTooltip}
+            customOpenIcon={customOpenIcon}
+            customCloseIcon={customCloseIcon}
             className={clsx([
               "absolute",
               "top-1/2",
               "-translate-y-1/2",
-              direction === "right" ? "-left-12" : "-right-12",
-              "bg-blue-500",
-              "text-white",
-              "p-2",
-              "rounded",
+              "right-0",
               "z-50",
               triggerClassName,
             ])}
-          >
-            Close
-          </DrawerTrigger>
-          {children}
+          />
+        ) : (
+          <ToggleButton
+            size="lg"
+            isOpen={isOpen}
+            onClick={handleToggle}
+            className={clsx(triggerClassName)}
+          />
+        )}
+        <DrawerContent
+          showHandle={showHandle}
+          className={clsx(["dark", contentClassName])}
+        >
+          <>
+            {direction === "right" && (
+              <ToggleButton
+                isOpen={isOpen}
+                onClick={handleToggle}
+                direction={customOpenIcon ? "vertical" : "horizontal"}
+                size="lg"
+                tooltipOpen={openDrawerTooltip}
+                tooltipClose={closeDrawerTooltip}
+                customOpenIcon={customOpenIcon}
+                customCloseIcon={customCloseIcon}
+                className={clsx([
+                  "absolute",
+                  "top-1/2",
+                  "-translate-y-1/2",
+                  "-left-5",
+                  "z-50",
+                  triggerClassName,
+                ])}
+              />
+            )}
+            {children}
+          </>
         </DrawerContent>
       </ShadcnDrawer>
     </>

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import React from "react";
+import { useState } from "react";
 import { Button } from "./Button";
 import {
   DrawerClose,
@@ -35,23 +35,42 @@ export const Drawer: React.FC<DrawerProps> = ({
   TriggerButton,
   initialIsOpen = false,
   showHandle,
+  direction = "right",
   ...props
 }) => {
   return (
-    <ShadcnDrawer defaultOpen={initialIsOpen} {...props}>
-      <DrawerTrigger>
-        {TriggerButton ?? (
-          <Button className={clsx(triggerClassName)}>Open</Button>
-        )}
-      </DrawerTrigger>
+    <>
+      <ShadcnDrawer direction={direction} {...props}>
+        <DrawerTrigger>
+          {TriggerButton ?? (
+            <Button className={clsx(triggerClassName)}>Open</Button>
+          )}
+        </DrawerTrigger>
 
-      <DrawerContent
-        showHandle={showHandle}
-        className={clsx(["dark", contentClassName])}
-      >
-        {children}
-      </DrawerContent>
-    </ShadcnDrawer>
+        <DrawerContent
+          showHandle={showHandle}
+          className={clsx(["dark", contentClassName])}
+        >
+          <DrawerTrigger
+            className={clsx([
+              "absolute",
+              "top-1/2",
+              "-translate-y-1/2",
+              direction === "right" ? "-left-12" : "-right-12",
+              "bg-blue-500",
+              "text-white",
+              "p-2",
+              "rounded",
+              "z-50",
+              triggerClassName,
+            ])}
+          >
+            Close
+          </DrawerTrigger>
+          {children}
+        </DrawerContent>
+      </ShadcnDrawer>
+    </>
   );
 };
 

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -17,6 +17,7 @@ interface DrawerProps {
   triggerClassName?: string;
   contentClassName?: string;
   TriggerButton?: React.ReactNode;
+  initialIsOpen?: boolean;
 }
 
 export const Drawer: React.FC<DrawerProps> = ({
@@ -24,9 +25,10 @@ export const Drawer: React.FC<DrawerProps> = ({
   triggerClassName,
   contentClassName,
   TriggerButton,
+  initialIsOpen = false,
 }) => {
   return (
-    <ShadcnDrawer>
+    <ShadcnDrawer defaultOpen={initialIsOpen}>
       <DrawerTrigger>
         {TriggerButton ?? (
           <Button className={clsx(triggerClassName)}>Open</Button>

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -17,11 +17,6 @@ interface DrawerProps {
   triggerClassName?: string;
   contentClassName?: string;
   TriggerButton?: React.ReactNode;
-
-  /**
-   * Remap `defaultOpen` to `initialIsOpen`.
-   * This standardizes the naming of the initial open state prop across the codebase.
-   */
   initialIsOpen?: boolean;
   showHandle?: boolean;
   direction?: ShadcnDrawerProps["direction"];
@@ -47,9 +42,21 @@ export const Drawer: React.FC<DrawerProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(initialIsOpen);
 
-  const handleToggle = () => {
-    setIsOpen((prev) => !prev);
-  };
+  const handleToggle = () => setIsOpen((prev) => !prev);
+
+  const renderToggleButton = (positionClass: string) => (
+    <ToggleButton
+      size="lg"
+      isOpen={isOpen}
+      onClick={handleToggle}
+      direction={customOpenIcon ? "vertical" : "horizontal"}
+      tooltipOpen={openDrawerTooltip}
+      tooltipClose={closeDrawerTooltip}
+      customOpenIcon={customOpenIcon}
+      customCloseIcon={customCloseIcon}
+      className={clsx([positionClass, triggerClassName])}
+    />
+  );
 
   return (
     <>
@@ -59,60 +66,19 @@ export const Drawer: React.FC<DrawerProps> = ({
         onOpenChange={setIsOpen}
         {...props}
       >
-        {direction === "right" ? (
-          <ToggleButton
-            size="lg"
-            isOpen={isOpen}
-            onClick={handleToggle}
-            direction={customOpenIcon ? "vertical" : "horizontal"}
-            tooltipOpen={openDrawerTooltip}
-            tooltipClose={closeDrawerTooltip}
-            customOpenIcon={customOpenIcon}
-            customCloseIcon={customCloseIcon}
-            className={clsx([
-              "absolute",
-              "top-1/2",
-              "-translate-y-1/2",
-              "right-0",
-              "z-50",
-              triggerClassName,
-            ])}
-          />
-        ) : (
-          <ToggleButton
-            size="lg"
-            isOpen={isOpen}
-            onClick={handleToggle}
-            className={clsx(triggerClassName)}
-          />
-        )}
+        {direction === "right"
+          ? renderToggleButton("absolute top-1/2 -translate-y-1/2 right-0 z-50")
+          : renderToggleButton("")}
+
         <DrawerContent
           showHandle={showHandle}
           className={clsx(["dark", contentClassName])}
         >
-          <>
-            {direction === "right" && (
-              <ToggleButton
-                isOpen={isOpen}
-                onClick={handleToggle}
-                direction={customOpenIcon ? "vertical" : "horizontal"}
-                size="lg"
-                tooltipOpen={openDrawerTooltip}
-                tooltipClose={closeDrawerTooltip}
-                customOpenIcon={customOpenIcon}
-                customCloseIcon={customCloseIcon}
-                className={clsx([
-                  "absolute",
-                  "top-1/2",
-                  "-translate-y-1/2",
-                  "-left-5",
-                  "z-50",
-                  triggerClassName,
-                ])}
-              />
+          {direction === "right" &&
+            renderToggleButton(
+              "absolute top-1/2 -translate-y-1/2 -left-5 z-50",
             )}
-            {children}
-          </>
+          {children}
         </DrawerContent>
       </ShadcnDrawer>
     </>

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -1,5 +1,6 @@
 import { ToggleButton } from "@/components";
 import clsx from "clsx";
+import { AnimatePresence, motion } from "framer-motion";
 import { useState } from "react";
 import {
   DrawerClose,
@@ -9,7 +10,6 @@ import {
   DrawerHeader,
   DrawerTitle,
   Drawer as ShadcnDrawer,
-  DrawerProps as ShadcnDrawerProps,
 } from "./shadcn/drawer";
 
 interface DrawerProps {
@@ -19,7 +19,7 @@ interface DrawerProps {
   TriggerButton?: React.ReactNode;
   initialIsOpen?: boolean;
   showHandle?: boolean;
-  direction?: ShadcnDrawerProps["direction"];
+  direction?: "bottom" | "right";
   openDrawerTooltip?: string;
   closeDrawerTooltip?: string;
   customOpenIcon?: string;
@@ -33,7 +33,7 @@ export const Drawer: React.FC<DrawerProps> = ({
   TriggerButton,
   initialIsOpen = false,
   showHandle,
-  direction = "right",
+  direction = "bottom",
   openDrawerTooltip = "Open",
   closeDrawerTooltip = "Close",
   customOpenIcon,
@@ -44,19 +44,43 @@ export const Drawer: React.FC<DrawerProps> = ({
 
   const handleToggle = () => setIsOpen((prev) => !prev);
 
-  const renderToggleButton = (positionClass: string) => (
-    <ToggleButton
-      size="lg"
-      isOpen={isOpen}
-      onClick={handleToggle}
-      direction={customOpenIcon ? "vertical" : "horizontal"}
-      tooltipOpen={openDrawerTooltip}
-      tooltipClose={closeDrawerTooltip}
-      customOpenIcon={customOpenIcon}
-      customCloseIcon={customCloseIcon}
-      className={clsx([positionClass, triggerClassName])}
-    />
-  );
+  const renderToggleButton = (
+    positionClass: string,
+    isVisible: boolean = true,
+    duration: number = 0.2,
+    direction: "bottom" | "right" = "bottom",
+  ) => {
+    const directionMap = {
+      bottom: "up",
+      right: "right",
+    } as const;
+
+    return (
+      <AnimatePresence>
+        {isVisible && (
+          <motion.div
+            key={"toggle-button"}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration }}
+          >
+            <ToggleButton
+              size="lg"
+              isOpen={isOpen}
+              onClick={handleToggle}
+              direction={directionMap[direction]}
+              tooltipOpen={openDrawerTooltip}
+              tooltipClose={closeDrawerTooltip}
+              customOpenIcon={customOpenIcon}
+              customCloseIcon={customCloseIcon}
+              className={clsx([positionClass, triggerClassName])}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    );
+  };
 
   return (
     <>
@@ -67,16 +91,24 @@ export const Drawer: React.FC<DrawerProps> = ({
         {...props}
       >
         {direction === "right"
-          ? renderToggleButton("absolute top-1/2 -translate-y-1/2 right-0 z-50")
+          ? renderToggleButton(
+              "absolute top-1/2 -translate-y-1/2 right-0 z-50",
+              // Fades in after closing the drawer
+              !isOpen,
+              1,
+              direction,
+            )
           : renderToggleButton("")}
 
         <DrawerContent
           showHandle={showHandle}
           className={clsx(["dark", contentClassName])}
         >
+          {/* Toggle button overlaying the drawer border */}
           {direction === "right" &&
             renderToggleButton(
               "absolute top-1/2 -translate-y-1/2 -left-5 z-50",
+              isOpen,
             )}
           {children}
         </DrawerContent>

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -10,6 +10,7 @@ import {
   DrawerTitle,
   DrawerTrigger,
   Drawer as ShadcnDrawer,
+  DrawerProps as ShadcnDrawerProps,
 } from "./shadcn/drawer";
 
 interface DrawerProps {
@@ -17,7 +18,14 @@ interface DrawerProps {
   triggerClassName?: string;
   contentClassName?: string;
   TriggerButton?: React.ReactNode;
+
+  /**
+   * Remap `defaultOpen` to `initialIsOpen`.
+   * This standardizes the naming of the initial open state prop across the codebase.
+   */
   initialIsOpen?: boolean;
+  showHandle?: boolean;
+  direction?: ShadcnDrawerProps["direction"];
 }
 
 export const Drawer: React.FC<DrawerProps> = ({
@@ -26,16 +34,21 @@ export const Drawer: React.FC<DrawerProps> = ({
   contentClassName,
   TriggerButton,
   initialIsOpen = false,
+  showHandle,
+  ...props
 }) => {
   return (
-    <ShadcnDrawer defaultOpen={initialIsOpen}>
+    <ShadcnDrawer defaultOpen={initialIsOpen} {...props}>
       <DrawerTrigger>
         {TriggerButton ?? (
           <Button className={clsx(triggerClassName)}>Open</Button>
         )}
       </DrawerTrigger>
 
-      <DrawerContent className={clsx(["dark", contentClassName])}>
+      <DrawerContent
+        showHandle={showHandle}
+        className={clsx(["dark", contentClassName])}
+      >
         {children}
       </DrawerContent>
     </ShadcnDrawer>

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -1,5 +1,4 @@
 import clsx from "clsx";
-import { useState } from "react";
 import { Button } from "./Button";
 import {
   DrawerClose,

--- a/src/components/ToggleButton.stories.tsx
+++ b/src/components/ToggleButton.stories.tsx
@@ -52,7 +52,7 @@ export const Default: Story = {
     size: "lg",
     tooltipOpen: "Open",
     tooltipClose: "Close",
-    direction: "vertical",
+    direction: "up",
     isOpen: false,
   },
   render: (args) => {

--- a/src/components/ToggleButton.stories.tsx
+++ b/src/components/ToggleButton.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { ToggleButton } from "./ToggleButton";
+
+const meta: Meta<typeof ToggleButton> = {
+  component: ToggleButton,
+  title: "Components/ToggleButton",
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    isOpen: {
+      control: "boolean",
+      description: "Controls whether the button is in the open state.",
+    },
+    onClick: {
+      action: "clicked",
+      description: "Callback function when the button is clicked.",
+    },
+    className: {
+      control: "text",
+      description: "Additional CSS classes for the button.",
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ToggleButton>;
+
+export const Default: Story = {
+  name: "Default",
+  args: {
+    isOpen: false,
+  },
+  render: (args) => {
+    const [isOpen, setIsOpen] = useState(args.isOpen);
+
+    return (
+      <ToggleButton
+        {...args}
+        isOpen={isOpen}
+        onClick={() => {
+          setIsOpen(!isOpen);
+          args.onClick?.();
+        }}
+      />
+    );
+  },
+};

--- a/src/components/ToggleButton.stories.tsx
+++ b/src/components/ToggleButton.stories.tsx
@@ -13,13 +13,31 @@ const meta: Meta<typeof ToggleButton> = {
       control: "boolean",
       description: "Controls whether the button is in the open state.",
     },
-    onClick: {
-      action: "clicked",
-      description: "Callback function when the button is clicked.",
-    },
     className: {
       control: "text",
       description: "Additional CSS classes for the button.",
+    },
+    tooltipOpen: {
+      control: "text",
+      description: "Tooltip label when the button is open.",
+    },
+    tooltipClose: {
+      control: "text",
+      description: "Tooltip label when the button is closed.",
+    },
+    size: {
+      control: {
+        type: "radio",
+        options: ["default", "sm", "lg"],
+      },
+      description: "Size of the toggle button.",
+    },
+    direction: {
+      control: {
+        type: "radio",
+        options: ["horizontal", "vertical"],
+      },
+      description: "Direction of the toggle button.",
     },
   },
 };
@@ -31,8 +49,11 @@ type Story = StoryObj<typeof ToggleButton>;
 export const Default: Story = {
   name: "Toggle Button",
   args: {
-    isOpen: false,
     size: "lg",
+    tooltipOpen: "Open",
+    tooltipClose: "Close",
+    direction: "vertical",
+    isOpen: false,
   },
   render: (args) => {
     const [isOpen, setIsOpen] = useState(args.isOpen);
@@ -42,7 +63,7 @@ export const Default: Story = {
         {...args}
         isOpen={isOpen}
         onClick={() => {
-          setIsOpen(!isOpen);
+          setIsOpen(() => !isOpen);
           args.onClick?.();
         }}
       />

--- a/src/components/ToggleButton.stories.tsx
+++ b/src/components/ToggleButton.stories.tsx
@@ -4,7 +4,7 @@ import { ToggleButton } from "./ToggleButton";
 
 const meta: Meta<typeof ToggleButton> = {
   component: ToggleButton,
-  title: "Components/ToggleButton",
+  title: "Components/Button/Toggle Button",
   parameters: {
     layout: "centered",
   },
@@ -29,9 +29,10 @@ export default meta;
 type Story = StoryObj<typeof ToggleButton>;
 
 export const Default: Story = {
-  name: "Default",
+  name: "Toggle Button",
   args: {
     isOpen: false,
+    size: "lg",
   },
   render: (args) => {
     const [isOpen, setIsOpen] = useState(args.isOpen);

--- a/src/components/ToggleButton.tsx
+++ b/src/components/ToggleButton.tsx
@@ -8,7 +8,7 @@ interface ToggleButtonProps {
   isOpen: boolean;
   onClick: () => void;
   className?: string;
-  direction: "horizontal" | "vertical";
+  direction?: "horizontal" | "vertical";
 }
 
 interface AnimatedIconProps {

--- a/src/components/ToggleButton.tsx
+++ b/src/components/ToggleButton.tsx
@@ -9,14 +9,35 @@ interface ToggleButtonProps {
   onClick: () => void;
   className?: string;
   direction?: "horizontal" | "vertical";
+  size?: "default" | "sm" | "lg";
 }
 
 interface AnimatedIconProps {
   icon: string;
   direction: ToggleButtonProps["direction"];
+  size: ToggleButtonProps["size"];
 }
 
-const AnimatedIcon: React.FC<AnimatedIconProps> = ({ icon, direction }) => {
+const sizeMap = {
+  sm: {
+    icon: "size-[16px]",
+    button: "size-[24px]",
+  },
+  default: {
+    icon: "size-[24px]",
+    button: "size-[32px]",
+  },
+  lg: {
+    icon: "size-[32px]",
+    button: "size-[40px]",
+  },
+};
+
+const AnimatedIcon: React.FC<AnimatedIconProps> = ({
+  icon,
+  direction,
+  size = "default",
+}) => {
   return (
     <motion.div
       key={icon}
@@ -34,7 +55,7 @@ const AnimatedIcon: React.FC<AnimatedIconProps> = ({ icon, direction }) => {
       ])}
     >
       <Icon
-        className={clsx(["size-[24px]", "pointer-events-none"])}
+        className={clsx([sizeMap[size].icon, "pointer-events-none"])}
         icon={icon}
       />
     </motion.div>
@@ -46,11 +67,11 @@ export const ToggleButton: React.FC<ToggleButtonProps> = ({
   onClick,
   className,
   direction = "vertical",
+  size = "default",
 }) => {
   return (
     <Button
       variant="rounded"
-      size="icon"
       onClick={onClick}
       tooltip={isOpen ? "Close" : "Open"}
       className={clsx([
@@ -66,19 +87,27 @@ export const ToggleButton: React.FC<ToggleButtonProps> = ({
         "text-white",
         "focus:ring-blue-500",
         "p-inset-2",
-        "size-[32px]",
         "transition-opacity",
         "duration-300",
         "text-slate-50",
         "relative",
+        sizeMap[size].button,
         className,
       ])}
     >
       <AnimatePresence initial={false}>
         {isOpen ? (
-          <AnimatedIcon direction={direction} icon="radix-icons:cross-2" />
+          <AnimatedIcon
+            direction={direction}
+            icon="radix-icons:cross-2"
+            size={size}
+          />
         ) : (
-          <AnimatedIcon direction={direction} icon="radix-icons:row-spacing" />
+          <AnimatedIcon
+            direction={direction}
+            icon="radix-icons:row-spacing"
+            size={size}
+          />
         )}
       </AnimatePresence>
     </Button>

--- a/src/components/ToggleButton.tsx
+++ b/src/components/ToggleButton.tsx
@@ -8,7 +8,7 @@ interface ToggleButtonProps {
   isOpen: boolean;
   onClick: () => void;
   className?: string;
-  direction?: "horizontal" | "vertical";
+  direction?: "up" | "down" | "left" | "right";
   size?: "default" | "sm" | "lg";
   tooltipOpen?: string;
   tooltipClose?: string;
@@ -40,9 +40,16 @@ const sizeMap = {
 
 const AnimatedIcon: React.FC<AnimatedIconProps> = ({
   icon,
-  direction,
+  direction = "down",
   size = "default",
 }) => {
+  const rotationMap = {
+    up: "rotate-180",
+    down: "rotate-0",
+    left: "rotate-90",
+    right: "-rotate-90",
+  };
+
   return (
     <motion.div
       key={icon}
@@ -55,7 +62,7 @@ const AnimatedIcon: React.FC<AnimatedIconProps> = ({
         "flex",
         "items-center",
         "justify-center",
-        direction === "vertical" ? "rotate-0" : "rotate-90",
+        rotationMap[direction],
         "size-full",
       ])}
     >
@@ -71,7 +78,7 @@ export const ToggleButton: React.FC<ToggleButtonProps> = ({
   isOpen,
   onClick,
   className,
-  direction = "vertical",
+  direction = "down",
   size = "default",
   tooltipOpen = "Open",
   tooltipClose = "Close",

--- a/src/components/ToggleButton.tsx
+++ b/src/components/ToggleButton.tsx
@@ -52,6 +52,7 @@ export const ToggleButton: React.FC<ToggleButtonProps> = ({
       variant="rounded"
       size="icon"
       onClick={onClick}
+      tooltip={isOpen ? "Close" : "Open"}
       className={clsx([
         "bg-gradient-to-r",
         "from-blue-500",

--- a/src/components/ToggleButton.tsx
+++ b/src/components/ToggleButton.tsx
@@ -1,0 +1,85 @@
+import { Icon } from "@iconify/react";
+import clsx from "clsx";
+import { AnimatePresence, motion } from "framer-motion";
+import React from "react";
+import { Button } from "./Button";
+
+interface ToggleButtonProps {
+  isOpen: boolean;
+  onClick: () => void;
+  className?: string;
+  direction: "horizontal" | "vertical";
+}
+
+interface AnimatedIconProps {
+  icon: string;
+  direction: ToggleButtonProps["direction"];
+}
+
+const AnimatedIcon: React.FC<AnimatedIconProps> = ({ icon, direction }) => {
+  return (
+    <motion.div
+      key={icon}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.2 }}
+      className={clsx([
+        "absolute",
+        "flex",
+        "items-center",
+        "justify-center",
+        direction === "vertical" ? "rotate-0" : "rotate-90",
+        "size-full",
+      ])}
+    >
+      <Icon
+        className={clsx(["size-[24px]", "pointer-events-none"])}
+        icon={icon}
+      />
+    </motion.div>
+  );
+};
+
+export const ToggleButton: React.FC<ToggleButtonProps> = ({
+  isOpen,
+  onClick,
+  className,
+  direction = "vertical",
+}) => {
+  return (
+    <Button
+      variant="rounded"
+      size="icon"
+      onClick={onClick}
+      className={clsx([
+        "bg-gradient-to-r",
+        "from-blue-500",
+        "to-emerald-600",
+        "hover:from-blue-400",
+        "hover:to-emerald-400",
+        "dark:from-blue-600",
+        "dark:to-emerald-600",
+        "dark:hover:from-blue-500",
+        "dark:hover:to-emerald-600",
+        "text-white",
+        "focus:ring-blue-500",
+        "p-inset-2",
+        "size-[32px]",
+        "transition-opacity",
+        "duration-300",
+        "text-slate-50",
+        "relative",
+        className,
+      ])}
+    >
+      <AnimatePresence initial={false}>
+        {isOpen ? (
+          <AnimatedIcon direction={direction} icon="radix-icons:cross-2" />
+        ) : (
+          <AnimatedIcon direction={direction} icon="radix-icons:row-spacing" />
+        )}
+      </AnimatePresence>
+    </Button>
+  );
+};

--- a/src/components/ToggleButton.tsx
+++ b/src/components/ToggleButton.tsx
@@ -10,6 +10,11 @@ interface ToggleButtonProps {
   className?: string;
   direction?: "horizontal" | "vertical";
   size?: "default" | "sm" | "lg";
+  tooltipOpen?: string;
+  tooltipClose?: string;
+  tooltipClassName?: string;
+  customOpenIcon?: string;
+  customCloseIcon?: string;
 }
 
 interface AnimatedIconProps {
@@ -68,12 +73,18 @@ export const ToggleButton: React.FC<ToggleButtonProps> = ({
   className,
   direction = "vertical",
   size = "default",
+  tooltipOpen = "Open",
+  tooltipClose = "Close",
+  tooltipClassName,
+  customOpenIcon,
+  customCloseIcon,
 }) => {
   return (
     <Button
       variant="rounded"
       onClick={onClick}
-      tooltip={isOpen ? "Close" : "Open"}
+      tooltip={isOpen ? tooltipClose : tooltipOpen}
+      tooltipClassName={clsx([tooltipClassName])}
       className={clsx([
         "bg-gradient-to-r",
         "from-blue-500",
@@ -99,13 +110,13 @@ export const ToggleButton: React.FC<ToggleButtonProps> = ({
         {isOpen ? (
           <AnimatedIcon
             direction={direction}
-            icon="radix-icons:cross-2"
+            icon={customCloseIcon || "radix-icons:cross-2"}
             size={size}
           />
         ) : (
           <AnimatedIcon
             direction={direction}
-            icon="radix-icons:row-spacing"
+            icon={customOpenIcon || "radix-icons:row-spacing"}
             size={size}
           />
         )}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,3 +2,4 @@ export * from "./Accordion";
 export * from "./Button";
 export * from "./Collapsible";
 export * from "./Drawer";
+export * from "./ToggleButton";

--- a/src/components/shadcn/drawer.tsx
+++ b/src/components/shadcn/drawer.tsx
@@ -96,22 +96,24 @@ function DrawerContent({
         ])}
         {...props}
       >
-        {showHandle && (
-          <DrawerPrimitive.Handle
-            className={clsx([
-              "bg-muted",
-              "mx-auto",
-              "mb-4",
-              "hidden",
-              "h-2",
-              "w-[100px]",
-              "shrink-0",
-              "rounded-full",
-              "group-data-[vaul-drawer-direction=top]/drawer-content:block",
-            ])}
-          />
-        )}
-        {children}
+        <>
+          {showHandle && (
+            <DrawerPrimitive.Handle
+              className={clsx([
+                "bg-muted",
+                "mx-auto",
+                "mb-4",
+                "hidden",
+                "h-2",
+                "w-[100px]",
+                "shrink-0",
+                "rounded-full",
+                "group-data-[vaul-drawer-direction=top]/drawer-content:block",
+              ])}
+            />
+          )}
+          {children}
+        </>
       </DrawerPrimitive.Content>
     </DrawerPortal>
   );

--- a/src/components/shadcn/drawer.tsx
+++ b/src/components/shadcn/drawer.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
 
+export type DrawerProps = React.ComponentProps<typeof DrawerPrimitive.Root>;
+
 import { cn } from "@/lib/utils";
 
 function Drawer({
@@ -46,8 +48,11 @@ function DrawerOverlay({
 function DrawerContent({
   className,
   children,
+  showHandle = true,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+}: React.ComponentProps<typeof DrawerPrimitive.Content> & {
+  showHandle?: boolean;
+}) {
   return (
     <DrawerPortal data-slot="drawer-portal">
       <DrawerOverlay />
@@ -63,7 +68,9 @@ function DrawerContent({
         )}
         {...props}
       >
-        <DrawerPrimitive.Handle className="bg-muted mx-auto mb-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=top]/drawer-content:block" />
+        {showHandle && (
+          <DrawerPrimitive.Handle className="bg-muted mx-auto mb-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=top]/drawer-content:block" />
+        )}
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>

--- a/src/components/shadcn/drawer.tsx
+++ b/src/components/shadcn/drawer.tsx
@@ -59,7 +59,7 @@ function DrawerContent({
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         className={cn(
-          "group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
+          "group/drawer-content bg-background fixed z-50 flex flex-col",
           "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
           "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
           "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",

--- a/src/components/shadcn/drawer.tsx
+++ b/src/components/shadcn/drawer.tsx
@@ -1,9 +1,8 @@
+import clsx from "clsx";
 import * as React from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
 
 export type DrawerProps = React.ComponentProps<typeof DrawerPrimitive.Root>;
-
-import { cn } from "@/lib/utils";
 
 function Drawer({
   ...props
@@ -36,10 +35,17 @@ function DrawerOverlay({
   return (
     <DrawerPrimitive.Overlay
       data-slot="drawer-overlay"
-      className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+      className={clsx([
+        "data-[state=open]:animate-in",
+        "data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0",
+        "data-[state=open]:fade-in-0",
+        "fixed",
+        "inset-0",
+        "z-50",
+        "bg-black/50",
         className,
-      )}
+      ])}
       {...props}
     />
   );
@@ -58,18 +64,52 @@ function DrawerContent({
       <DrawerOverlay />
       <DrawerPrimitive.Content
         data-slot="drawer-content"
-        className={cn(
-          "group/drawer-content bg-background fixed z-50 flex flex-col",
-          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
-          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
-          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
-          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+        className={clsx([
+          "group/drawer-content",
+          "bg-background",
+          "fixed",
+          "z-50",
+          "flex",
+          "flex-col",
+          "data-[vaul-drawer-direction=top]:inset-x-0",
+          "data-[vaul-drawer-direction=top]:top-0",
+          "data-[vaul-drawer-direction=top]:mb-24",
+          "data-[vaul-drawer-direction=top]:max-h-[80vh]",
+          "data-[vaul-drawer-direction=top]:rounded-b-lg",
+          "data-[vaul-drawer-direction=top]:border-b",
+          "data-[vaul-drawer-direction=bottom]:inset-x-0",
+          "data-[vaul-drawer-direction=bottom]:bottom-0",
+          "data-[vaul-drawer-direction=bottom]:mt-24",
+          "data-[vaul-drawer-direction=bottom]:rounded-t-lg",
+          "data-[vaul-drawer-direction=bottom]:border-t",
+          "data-[vaul-drawer-direction=right]:inset-y-0",
+          "data-[vaul-drawer-direction=right]:right-0",
+          "data-[vaul-drawer-direction=right]:w-3/4",
+          "data-[vaul-drawer-direction=right]:border-l",
+          "data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "data-[vaul-drawer-direction=left]:inset-y-0",
+          "data-[vaul-drawer-direction=left]:left-0",
+          "data-[vaul-drawer-direction=left]:w-3/4",
+          "data-[vaul-drawer-direction=left]:border-r",
+          "data-[vaul-drawer-direction=left]:sm:max-w-sm",
           className,
-        )}
+        ])}
         {...props}
       >
         {showHandle && (
-          <DrawerPrimitive.Handle className="bg-muted mx-auto mb-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=top]/drawer-content:block" />
+          <DrawerPrimitive.Handle
+            className={clsx([
+              "bg-muted",
+              "mx-auto",
+              "mb-4",
+              "hidden",
+              "h-2",
+              "w-[100px]",
+              "shrink-0",
+              "rounded-full",
+              "group-data-[vaul-drawer-direction=top]/drawer-content:block",
+            ])}
+          />
         )}
         {children}
       </DrawerPrimitive.Content>
@@ -81,7 +121,7 @@ function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="drawer-header"
-      className={cn("flex flex-col gap-1.5 p-4", className)}
+      className={clsx(["flex", "flex-col", "gap-1.5", "p-4", className])}
       {...props}
     />
   );
@@ -91,7 +131,14 @@ function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="drawer-footer"
-      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      className={clsx([
+        "mt-auto",
+        "flex",
+        "flex-col",
+        "gap-2",
+        "p-4",
+        className,
+      ])}
       {...props}
     />
   );
@@ -104,7 +151,7 @@ function DrawerTitle({
   return (
     <DrawerPrimitive.Title
       data-slot="drawer-title"
-      className={cn("text-foreground font-semibold", className)}
+      className={clsx(["text-foreground", "font-semibold", className])}
       {...props}
     />
   );
@@ -117,7 +164,7 @@ function DrawerDescription({
   return (
     <DrawerPrimitive.Description
       data-slot="drawer-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={clsx(["text-muted-foreground", "text-sm", className])}
       {...props}
     />
   );

--- a/src/components/shadcn/tooltip.tsx
+++ b/src/components/shadcn/tooltip.tsx
@@ -1,7 +1,6 @@
-import * as React from "react"
-import * as TooltipPrimitive from "@radix-ui/react-tooltip"
-
-import { cn } from "@/lib/utils"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import clsx from "clsx";
+import * as React from "react";
 
 function TooltipProvider({
   delayDuration = 0,
@@ -13,7 +12,7 @@ function TooltipProvider({
       delayDuration={delayDuration}
       {...props}
     />
-  )
+  );
 }
 
 function Tooltip({
@@ -23,18 +22,21 @@ function Tooltip({
     <TooltipProvider>
       <TooltipPrimitive.Root data-slot="tooltip" {...props} />
     </TooltipProvider>
-  )
+  );
 }
 
 function TooltipTrigger({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+  return (
+    <TooltipPrimitive.Trigger data-slot="tooltip-trigger" asChild {...props} />
+  );
 }
 
 function TooltipContent({
   className,
   sideOffset = 0,
+  alignOffset = 0,
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
@@ -43,17 +45,47 @@ function TooltipContent({
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
         sideOffset={sideOffset}
-        className={cn(
-          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
-          className
-        )}
+        alignOffset={alignOffset}
+        className={clsx([
+          "bg-primary",
+          "text-primary-foreground",
+          "animate-in",
+          "fade-in-0",
+          "zoom-in-95",
+          "data-[state=closed]:animate-out",
+          "data-[state=closed]:fade-out-0",
+          "data-[state=closed]:zoom-out-95",
+          "data-[side=bottom]:slide-in-from-top-2",
+          "data-[side=left]:slide-in-from-right-2",
+          "data-[side=right]:slide-in-from-left-2",
+          "data-[side=top]:slide-in-from-bottom-2",
+          "z-50",
+          "w-fit",
+          "origin-(--radix-tooltip-content-transform-origin)",
+          "rounded-md",
+          "px-3",
+          "py-1.5",
+          "text-xs",
+          "text-balance",
+          className,
+        ])}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow
+          className={clsx([
+            "bg-primary",
+            "fill-primary",
+            "z-50",
+            "size-2.5",
+            "translate-y-[calc(-50%_-_2px)]",
+            "rotate-45",
+            "rounded-[2px]",
+          ])}
+        />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
-  )
+  );
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/src/components/withTooltip.tsx
+++ b/src/components/withTooltip.tsx
@@ -3,6 +3,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/shadcn/tooltip";
+import clsx from "clsx";
 import React from "react";
 
 /**
@@ -26,14 +27,20 @@ import React from "react";
 export function withTooltip<T extends object>(
   WrappedComponent: React.ComponentType<T>,
 ) {
-  return ({ tooltip, ...props }: T & { tooltip?: string }) => {
+  return ({
+    tooltip,
+    tooltipClassName,
+    ...props
+  }: T & { tooltip?: string; tooltipClassName?: string }) => {
     if (tooltip) {
       return (
         <Tooltip>
           <TooltipTrigger>
             <WrappedComponent {...(props as T)} />
           </TooltipTrigger>
-          <TooltipContent>{tooltip}</TooltipContent>
+          <TooltipContent className={clsx(tooltipClassName)}>
+            {tooltip}
+          </TooltipContent>
         </Tooltip>
       );
     }

--- a/src/components/withTooltip.tsx
+++ b/src/components/withTooltip.tsx
@@ -1,0 +1,42 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/shadcn/tooltip";
+import React from "react";
+
+/**
+ * A higher-order component (HOC) that wraps a given component and adds tooltip functionality.
+ *
+ * @template T - The props type of the wrapped component.
+ * @param WrappedComponent - The React component to be wrapped with tooltip functionality.
+ * @returns A new component that renders the wrapped component with an optional tooltip.
+ *
+ * The returned component accepts all the props of the wrapped component, along with an additional
+ * `tooltip` prop. If the `tooltip` prop is provided, the wrapped component will be displayed
+ * inside a tooltip trigger, and the tooltip content will be displayed when triggered.
+ *
+ * Example usage:
+ * ```tsx
+ * const ButtonWithTooltip = withTooltip(Button);
+ *
+ * <ButtonWithTooltip tooltip="Click me!">Click</ButtonWithTooltip>
+ * ```
+ */
+export function withTooltip<T extends object>(
+  WrappedComponent: React.ComponentType<T>,
+) {
+  return ({ tooltip, ...props }: T & { tooltip?: string }) => {
+    if (tooltip) {
+      return (
+        <Tooltip>
+          <TooltipTrigger>
+            <WrappedComponent {...(props as T)} />
+          </TooltipTrigger>
+          <TooltipContent>{tooltip}</TooltipContent>
+        </Tooltip>
+      );
+    }
+    return <WrappedComponent {...(props as T)} />;
+  };
+}

--- a/src/examples/GraphTheory/GraphKey.tsx
+++ b/src/examples/GraphTheory/GraphKey.tsx
@@ -8,18 +8,23 @@ interface GraphKeyProps {
   className?: string;
   drawerTriggerButton?: React.ReactNode;
   collapsibleTitle?: string | React.ReactNode;
+  initialOpen?: boolean;
 }
 
 export const GraphKey: React.FC<GraphKeyProps> = ({
   keyTable,
   className,
   collapsibleTitle = "Key",
+  initialOpen = false,
 }) => {
   return (
     <>
       {/* Mobile View: Drawer */}
       <div className="block md:hidden">
-        <Drawer TriggerButton={<Button>{collapsibleTitle}</Button>}>
+        <Drawer
+          initialIsOpen={initialOpen}
+          TriggerButton={<Button>{collapsibleTitle}</Button>}
+        >
           <table
             className={clsx(
               "text-white",
@@ -42,7 +47,7 @@ export const GraphKey: React.FC<GraphKeyProps> = ({
 
       {/* Desktop View: Collapsible */}
       <div className="hidden md:block">
-        <Collapsible Title={collapsibleTitle}>
+        <Collapsible Title={collapsibleTitle} initialOpen={initialOpen}>
           <table
             className={clsx(
               "text-white",

--- a/src/examples/GraphTheory/Grids/GridBFSShortestPath.stories.tsx
+++ b/src/examples/GraphTheory/Grids/GridBFSShortestPath.stories.tsx
@@ -1,4 +1,3 @@
-import { Button, Collapsible, Drawer } from "@/components";
 import type { Meta, StoryObj } from "@storybook/react";
 import clsx from "clsx";
 import { Grid } from ".";

--- a/src/examples/GraphTheory/Grids/GridToGraph.stories.tsx
+++ b/src/examples/GraphTheory/Grids/GridToGraph.stories.tsx
@@ -60,7 +60,7 @@ const meta: Meta<typeof Grid> = {
             "overflow-hidden",
           ])}
         >
-          <div className={clsx(["h-2/3", "flex", "w-full"])}>
+          <div className={clsx(["h-2/3", "w-1/2", "flex", "w-full"])}>
             <Story
               args={{
                 matrix: testMatrix,
@@ -68,7 +68,7 @@ const meta: Meta<typeof Grid> = {
               }}
             />
           </div>
-          <div className={clsx(["h-2/3", "w-full"])}>
+          <div className={clsx(["h-2/3", "w-1/2"])}>
             <GraphNodeToNeigbourList graph={graph} />
           </div>
         </div>

--- a/src/examples/GraphTheory/Grids/GridToGraph.stories.tsx
+++ b/src/examples/GraphTheory/Grids/GridToGraph.stories.tsx
@@ -1,3 +1,4 @@
+import { Drawer } from "@/components";
 import type { Meta, StoryObj } from "@storybook/react";
 import clsx from "clsx";
 
@@ -68,9 +69,14 @@ const meta: Meta<typeof Grid> = {
               }}
             />
           </div>
-          <div className={clsx(["h-2/3", "w-1/2"])}>
+          <Drawer
+            initialIsOpen
+            direction="right"
+            showHandle={false}
+            contentClassName={clsx(["min-w-1/2"])}
+          >
             <GraphNodeToNeigbourList graph={graph} />
-          </div>
+          </Drawer>
         </div>
       );
     },

--- a/src/examples/GraphTheory/Grids/GridToGraph.stories.tsx
+++ b/src/examples/GraphTheory/Grids/GridToGraph.stories.tsx
@@ -59,21 +59,20 @@ const meta: Meta<typeof Grid> = {
             "p-4",
             "place-items-center",
             "overflow-hidden",
+            "flex-col md:flex-row",
           ])}
         >
-          <div className={clsx(["h-2/3", "w-1/2", "flex", "w-full"])}>
-            <Story
-              args={{
-                matrix: testMatrix,
-                tileColorOverride: tileColorOverrides,
-              }}
-            />
-          </div>
+          <Story
+            args={{
+              matrix: testMatrix,
+              tileColorOverride: tileColorOverrides,
+            }}
+          />
           <Drawer
             initialIsOpen
-            direction="right"
+            direction={window.innerWidth >= 768 ? "right" : "bottom"}
             showHandle={false}
-            contentClassName={clsx(["min-w-1/2"])}
+            contentClassName={clsx(["min-w-1/3", "min-h-1/3", "h-full"])}
           >
             <GraphNodeToNeigbourList graph={graph} />
           </Drawer>

--- a/src/examples/GraphTheory/Grids/GridToGraph.stories.tsx
+++ b/src/examples/GraphTheory/Grids/GridToGraph.stories.tsx
@@ -70,9 +70,9 @@ const meta: Meta<typeof Grid> = {
             }}
           />
           <Drawer
-            initialIsOpen
             direction={window.innerWidth >= 768 ? "right" : "bottom"}
             showHandle={false}
+            customOpenIcon="radix-icons:arrow-left"
             contentClassName={clsx([
               "max-h-1/2",
               "h-1/2",
@@ -80,6 +80,8 @@ const meta: Meta<typeof Grid> = {
               "md:h-full",
               "md:min-w-1/2",
             ])}
+            openDrawerTooltip={"Show Graph"}
+            closeDrawerTooltip={"Hide Graph"}
           >
             <GraphNodeToNeigbourList graph={graph} />
           </Drawer>

--- a/src/examples/GraphTheory/Grids/GridToGraph.stories.tsx
+++ b/src/examples/GraphTheory/Grids/GridToGraph.stories.tsx
@@ -59,7 +59,8 @@ const meta: Meta<typeof Grid> = {
             "p-4",
             "place-items-center",
             "overflow-hidden",
-            "flex-col md:flex-row",
+            "flex-col",
+            "md:flex-row",
           ])}
         >
           <Story
@@ -72,7 +73,13 @@ const meta: Meta<typeof Grid> = {
             initialIsOpen
             direction={window.innerWidth >= 768 ? "right" : "bottom"}
             showHandle={false}
-            contentClassName={clsx(["min-w-1/3", "min-h-1/3", "h-full"])}
+            contentClassName={clsx([
+              "max-h-1/2",
+              "h-1/2",
+              "md:max-h-full",
+              "md:h-full",
+              "md:min-w-1/2",
+            ])}
           >
             <GraphNodeToNeigbourList graph={graph} />
           </Drawer>

--- a/src/examples/GraphTheory/Grids/GridToGraph.stories.tsx
+++ b/src/examples/GraphTheory/Grids/GridToGraph.stories.tsx
@@ -1,4 +1,9 @@
-import { Drawer } from "@/components";
+import {
+  Drawer,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components";
 import type { Meta, StoryObj } from "@storybook/react";
 import clsx from "clsx";
 
@@ -72,7 +77,7 @@ const meta: Meta<typeof Grid> = {
           <Drawer
             direction={window.innerWidth >= 768 ? "right" : "bottom"}
             showHandle={false}
-            customOpenIcon="radix-icons:arrow-left"
+            customOpenIcon="radix-icons:arrow-up"
             contentClassName={clsx([
               "max-h-1/2",
               "h-1/2",
@@ -83,7 +88,15 @@ const meta: Meta<typeof Grid> = {
             openDrawerTooltip={"Show Graph"}
             closeDrawerTooltip={"Hide Graph"}
           >
-            <GraphNodeToNeigbourList graph={graph} />
+            <>
+              <DrawerHeader>
+                <DrawerTitle>Graph - Adjacency List Representation</DrawerTitle>
+                <DrawerDescription>
+                  The graph generated from the grid.
+                </DrawerDescription>
+              </DrawerHeader>
+              <GraphNodeToNeigbourList graph={graph} />
+            </>
           </Drawer>
         </div>
       );

--- a/src/examples/GraphTheory/MarkdownComponents/GraphNodeToNeigbourList.tsx
+++ b/src/examples/GraphTheory/MarkdownComponents/GraphNodeToNeigbourList.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { EdgeToNode } from "./EdgeToNode";
 import { Node } from "./Node";
 
+import { Button } from "@/components";
 import { HiArrowDown } from "react-icons/hi";
 import type { Graph } from "../Grids";
 
@@ -46,7 +47,7 @@ export const GraphNodeToNeigbourList: React.FC<
           "[&>*:nth-child(even)]:bg-secondary-600/10",
           "space-y-3",
           "max-h-full",
-          "overflow-y-auto",
+          "overflow-auto",
           "grow",
         ])}
       >
@@ -78,22 +79,9 @@ export const GraphNodeToNeigbourList: React.FC<
           </li>
         ))}
       </ul>
-      <button
+      <Button
         onClick={() => setAutoScroll((prev) => !prev)}
-        className={clsx([
-          "m-2",
-          "px-4",
-          "py-2",
-          "bg-blue-500",
-          "text-white",
-          "rounded-sm",
-          "self-center",
-          "flex",
-          "items-center",
-          "hover:bg-blue-600",
-          "transition",
-          "min-w-[200px]",
-        ])}
+        className={clsx(["m-4", "self-center"])}
       >
         {autoScroll ? "Disable Auto-Scroll" : "Enable Auto-Scroll"}
         {autoScroll ? (
@@ -101,7 +89,7 @@ export const GraphNodeToNeigbourList: React.FC<
         ) : (
           <HiArrowDown className="w-4 h-4 ml-2 rotate-0 transition-transform ease-in" />
         )}
-      </button>
+      </Button>
     </div>
   );
 };

--- a/src/examples/GraphTheory/MarkdownComponents/Node.tsx
+++ b/src/examples/GraphTheory/MarkdownComponents/Node.tsx
@@ -19,6 +19,7 @@ export function Node({ name, size = 32, className, ...props }: NodeProps) {
         "my-auto",
         "text-xs",
         "text-white",
+        "min-w-[32px]",
         className,
       ])}
       style={{ width: size, height: size }}


### PR DESCRIPTION
This pull request includes several changes to refactor React components, improve code readability, and add new features. The most important changes include the introduction of the `ToggleButton` component, refactoring of `Drawer` and `Collapsible` components, and the use of `clsx` for managing `className` values.

### New Components:
* [`src/components/ToggleButton.tsx`](diffhunk://#diff-8eb7d65c39a12b6a8a2eaa9cdff488ada5adaeaff2bd11d7f15a2fafa0a09518R1-R133): Introduced a new `ToggleButton` component with customizable icons, tooltips, and sizes.
* [`src/components/ToggleButton.stories.tsx`](diffhunk://#diff-82cee96f21a04278407f9cb2e5d55854fe90f3587ed62946c0975ca1d275e6f4R1-R72): Added Storybook stories for the `ToggleButton` component.

### Refactoring:
* [`.github/prompts/tw-classnames-split.prompt.md`](diffhunk://#diff-d30c95e4219f55ec84ac3654822f56eb0d3e9138cfacc1817f40215ba274774bR1-R26): Added a prompt to refactor React components to use `clsx` for managing `className` values.
* [`src/components/Accordion.tsx`](diffhunk://#diff-7855ce750b73094a291f92499f33532c0cade55db5ef70ee7a5a769f21d20a42R3): Refactored to use `useState` directly instead of `React.useState`. [[1]](diffhunk://#diff-7855ce750b73094a291f92499f33532c0cade55db5ef70ee7a5a769f21d20a42R3) [[2]](diffhunk://#diff-7855ce750b73094a291f92499f33532c0cade55db5ef70ee7a5a769f21d20a42L20-R21)
* [`src/components/Button.tsx`](diffhunk://#diff-1e4ab16772826f4d218576ae2acae4e6ab1c99196422e2eecd23db06ff869357R3-L20): Refactored `Button` component to use `withTooltip` higher-order component.
* [`src/components/Collapsible.tsx`](diffhunk://#diff-ca1f5ad130cef0c2c08d2dc060b01e9b64e49cfba5095baae1d6a0bc1380972bL5-R26): Refactored to use `ToggleButton` and `useState` directly. [[1]](diffhunk://#diff-ca1f5ad130cef0c2c08d2dc060b01e9b64e49cfba5095baae1d6a0bc1380972bL5-R26) [[2]](diffhunk://#diff-ca1f5ad130cef0c2c08d2dc060b01e9b64e49cfba5095baae1d6a0bc1380972bL58-R64) [[3]](diffhunk://#diff-ca1f5ad130cef0c2c08d2dc060b01e9b64e49cfba5095baae1d6a0bc1380972bL79-L123)
* [`src/components/Drawer.tsx`](diffhunk://#diff-9363d87f9e16f04e5a701c7afa490e52afbb368545f3b8ce24503f212e2d145dR1-L11): Refactored to add new props and use `ToggleButton` for toggling the drawer. [[1]](diffhunk://#diff-9363d87f9e16f04e5a701c7afa490e52afbb368545f3b8ce24503f212e2d145dR1-L11) [[2]](diffhunk://#diff-9363d87f9e16f04e5a701c7afa490e52afbb368545f3b8ce24503f212e2d145dR20-R116)

### Updates to Stories:
* [`src/components/Accordion.stories.tsx`](diffhunk://#diff-95514a6321ebfa0d4966f34614a774890148a62189075245f8cefd45f1d98935L18-R18): Updated the story for the `Accordion` component.
* [`src/components/Button.stories.tsx`](diffhunk://#diff-090345755043ab5d906f6a0b5e53f13f715059ee0dcfd830f282b29d486c1287L2-R2): Updated the import statement for the `Button` component.
* [`src/components/Collapsible.stories.tsx`](diffhunk://#diff-364f14327b7177c0ea5677265643505fcbe1e33fc483bb08b081059cc9ad0aacL18-R18): Updated the story for the `Collapsible` component.
* [`src/components/Drawer.stories.tsx`](diffhunk://#diff-708e5db5347a9e49817ea27de7638a7316a0286431aed2b7276b31ff51d21029L5-R5): Added new stories for bottom and right aligned `Drawer` components. [[1]](diffhunk://#diff-708e5db5347a9e49817ea27de7638a7316a0286431aed2b7276b31ff51d21029L5-R5) [[2]](diffhunk://#diff-708e5db5347a9e49817ea27de7638a7316a0286431aed2b7276b31ff51d21029L20-R131) [[3]](diffhunk://#diff-708e5db5347a9e49817ea27de7638a7316a0286431aed2b7276b31ff51d21029L39-R140)

### Miscellaneous:
* [`src/components/index.ts`](diffhunk://#diff-7fd43b0b162a214d655a8176a345b983bfa23ff95be8e4059e587cf9db3fc51fR5): Exported the new `ToggleButton` component.
* [`src/components/shadcn/drawer.tsx`](diffhunk://#diff-be0ca7e34be2222e62a20aeaf6e1e1f82f90a9b02e3195a3b9513e53091d959dR1-R5): Replaced `cn` utility with `clsx` for class name management. [[1]](diffhunk://#diff-be0ca7e34be2222e62a20aeaf6e1e1f82f90a9b02e3195a3b9513e53091d959dR1-R5) [[2]](diffhunk://#diff-be0ca7e34be2222e62a20aeaf6e1e1f82f90a9b02e3195a3b9513e53091d959dL37-R48)